### PR TITLE
fix: correct name spelling to Yurii Kostiuk

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ flowchart LR
 <table>
   <tr>
     <td align="center" width="50%">
-      <img src="img/Yuriy.gif" width="180" alt="Yurii Kostyuk"><br>
-      <b>Yurii Kostyuk</b><br>
+      <img src="img/Yuriy.gif" width="180" alt="Yurii Kostiuk"><br>
+      <b>Yurii Kostiuk</b><br>
       Cloud Security &amp; IAM<br>
       <sub>Lead Security Architect, PETRONAS · ex-Okta</sub><br>
       <a href="https://www.linkedin.com/in/yuriy-kostyuk-778900ab/">LinkedIn</a>

--- a/index.html
+++ b/index.html
@@ -282,10 +282,10 @@
         <div class="team__grid">
 
             <article class="member reveal">
-                <div class="member__media"><img src="img/Yuriy.gif" alt="Yurii Kostyuk"></div>
+                <div class="member__media"><img src="img/Yuriy.gif" alt="Yurii Kostiuk"></div>
                 <div class="member__body">
                     <span class="member__role">Co-founder · Cloud Security &amp; IAM</span>
-                    <h3>Yurii Kostyuk</h3>
+                    <h3>Yurii Kostiuk</h3>
                     <p class="where">Lead Security Architect, PETRONAS · ex-Cloud Native Architect, Okta</p>
                     <p>IAM solutions architect and cloud security consultant. Yurii defines enterprise-wide security strategy and designs secure, scalable architectures across hybrid and cloud-native environments — Zero Trust, identity, DevSecOps and platform resilience on AWS and GCP.</p>
                     <div class="member__skills">


### PR DESCRIPTION
Corrects the displayed founder name from **Yurii Kostyuk** to **Yurii Kostiuk** in the team section and README. Image filename (`img/Yuriy.gif`) and the real LinkedIn URL are intentionally left unchanged.