### PR TITLE
fix: update Yurii Kostiuk LinkedIn URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ flowchart LR
       <b>Yurii Kostiuk</b><br>
       Cloud Security &amp; IAM<br>
       <sub>Lead Security Architect, PETRONAS · ex-Okta</sub><br>
-      <a href="https://www.linkedin.com/in/yuriy-kostyuk-778900ab/">LinkedIn</a>
+      <a href="https://www.linkedin.com/in/yurii-kostiuk-778900ab/">LinkedIn</a>
     </td>
     <td align="center" width="50%">
       <img src="img/Tania.gif" width="180" alt="Tania Fedirko"><br>

--- a/index.html
+++ b/index.html
@@ -291,7 +291,7 @@
                     <div class="member__skills">
                         <span>IAM</span><span>Zero Trust</span><span>AWS / GCP</span><span>Terraform</span><span>Kubernetes</span><span>Go</span>
                     </div>
-                    <a class="member__link" href="https://www.linkedin.com/in/yuriy-kostyuk-778900ab/" target="_blank" rel="noopener">
+                    <a class="member__link" href="https://www.linkedin.com/in/yurii-kostiuk-778900ab/" target="_blank" rel="noopener">
                         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.1c0-1.7-.03-3.9-2.38-3.9-2.38 0-2.75 1.86-2.75 3.78V24h-4V8z"/></svg>
                         Connect on LinkedIn
                     </a>


### PR DESCRIPTION
Updates Yurii's LinkedIn profile link to the new slug `yurii-kostiuk-778900ab` in the team section and README. Tania's link unchanged.