### PR TITLE
feat: liven up the hero dashboard cost graph

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,14 +79,17 @@
                 <!-- cost card -->
                 <rect x="20" y="58" width="440" height="172" rx="14" fill="#ffffff" stroke="#14110f"/>
                 <text x="40" y="92" font-family="'Space Grotesk', sans-serif" font-size="12" font-weight="600" letter-spacing="1.5" fill="#8a8175">CLOUD + AI SPEND</text>
-                <text x="40" y="128" font-family="'Space Grotesk', sans-serif" font-size="34" font-weight="700" fill="#d98c00">&#8722;30%</text>
+                <text id="costNum" x="40" y="128" font-family="'Space Grotesk', sans-serif" font-size="34" font-weight="700" fill="#d98c00">&#8722;30%</text>
                 <text x="150" y="128" font-family="'Inter', sans-serif" font-size="13" fill="#8a8175">this quarter</text>
                 <!-- chart -->
                 <path class="hero-dash__area" d="M44,150 L116,166 L188,146 L260,178 L332,172 L404,194 L440,202 L440,212 L44,212 Z" fill="#f4a91b" fill-opacity="0.16"/>
                 <path class="hero-dash__line" d="M44,150 L116,166 L188,146 L260,178 L332,172 L404,194 L440,202" fill="none" stroke="#f4a91b" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
                 <g fill="#e8431c">
-                    <circle cx="44" cy="150" r="3.5"/><circle cx="188" cy="146" r="3.5"/><circle cx="440" cy="202" r="4" fill="#14110f"/>
+                    <circle cx="44" cy="150" r="3.5"/><circle cx="188" cy="146" r="3.5"/>
                 </g>
+                <circle class="hero-dash__end" cx="440" cy="202" r="5" fill="none" stroke="#14110f" stroke-width="1.5"/>
+                <circle cx="440" cy="202" r="4" fill="#14110f"/>
+                <circle class="hero-dash__travel" r="4.5" fill="#e8431c"/>
                 <line x1="40" y1="212" x2="440" y2="212" stroke="#14110f" stroke-opacity="0.12"/>
 
                 <!-- security tile -->
@@ -522,6 +525,18 @@
     document.getElementById('year').textContent = new Date().getFullYear();
 
     var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    // hero dashboard: count up the cost-reduction figure
+    var costEl = document.getElementById('costNum');
+    if (costEl && !reduced) {
+        var n = 0;
+        costEl.textContent = '−0%';
+        var ci = setInterval(function () {
+            n += 2;
+            if (n >= 30) { n = 30; clearInterval(ci); }
+            costEl.textContent = '−' + n + '%';
+        }, 45);
+    }
 
     // scroll progress bar
     var bar = document.getElementById('scrollbar');

--- a/style.css
+++ b/style.css
@@ -196,10 +196,20 @@ h1, h2, h3, h4 {
 @keyframes dash-draw { from { stroke-dasharray: 520; stroke-dashoffset: 520; } to { stroke-dasharray: 520; stroke-dashoffset: 0; } }
 .hero-dash__area { animation: dash-fade 1.2s ease .7s backwards; }
 @keyframes dash-fade { from { opacity: 0; } }
-.hero-dash__bar { transform-box: fill-box; transform-origin: bottom; animation: dash-bar .7s var(--ease) backwards; }
-@keyframes dash-bar { from { transform: scaleY(0); } }
+.hero-dash__bar { transform-box: fill-box; transform-origin: bottom; animation: dash-bar 3.2s ease-in-out infinite; }
+@keyframes dash-bar { 0% { transform: scaleY(.22); } 45% { transform: scaleY(1); } 75% { transform: scaleY(1); } 100% { transform: scaleY(.22); } }
 .hero-dash__dot { animation: dash-pulse 2s ease-in-out infinite; }
 @keyframes dash-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
+
+/* live cost-graph: a point that tracks the declining line, + a pulsing endpoint */
+.hero-dash__travel {
+  offset-path: path('M44 150 L116 166 L188 146 L260 178 L332 172 L404 194 L440 202');
+  offset-rotate: 0deg;
+  animation: dash-travel 4.5s linear infinite;
+}
+@keyframes dash-travel { from { offset-distance: 0%; } to { offset-distance: 100%; } }
+.hero-dash__end { transform-box: fill-box; transform-origin: center; animation: dash-ring 2.2s ease-out infinite; }
+@keyframes dash-ring { 0% { transform: scale(.5); opacity: .7; } 100% { transform: scale(2.4); opacity: 0; } }
 .hero__badge {
   position: absolute;
   font-family: var(--font-head);


### PR DESCRIPTION
Adds motion to the hero panel: a point tracking the declining cost line, a count-up of the −30% figure, a pulsing endpoint, and breathing token bars. Reduced-motion safe.