### PR TITLE
feat: make AI-token bars continuously breathe

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,6 +526,18 @@
 
     var reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+    // hero dashboard: keep the AI-token bars alive with gentle random motion
+    var tokenBars = document.querySelectorAll('.hero-dash__bar');
+    if (tokenBars.length && !reduced) {
+        var jiggleBars = function () {
+            for (var i = 0; i < tokenBars.length; i++) {
+                tokenBars[i].style.transform = 'scaleY(' + (0.38 + Math.random() * 0.62).toFixed(3) + ')';
+            }
+        };
+        jiggleBars();
+        setInterval(jiggleBars, 1150);
+    }
+
     // hero dashboard: count up the cost-reduction figure
     var costEl = document.getElementById('costNum');
     if (costEl && !reduced) {

--- a/style.css
+++ b/style.css
@@ -196,8 +196,7 @@ h1, h2, h3, h4 {
 @keyframes dash-draw { from { stroke-dasharray: 520; stroke-dashoffset: 520; } to { stroke-dasharray: 520; stroke-dashoffset: 0; } }
 .hero-dash__area { animation: dash-fade 1.2s ease .7s backwards; }
 @keyframes dash-fade { from { opacity: 0; } }
-.hero-dash__bar { transform-box: fill-box; transform-origin: bottom; animation: dash-bar 3.2s ease-in-out infinite; }
-@keyframes dash-bar { 0% { transform: scaleY(.22); } 45% { transform: scaleY(1); } 75% { transform: scaleY(1); } 100% { transform: scaleY(.22); } }
+.hero-dash__bar { transform-box: fill-box; transform-origin: bottom; transition: transform 1s cubic-bezier(.4, 0, .2, 1); }
 .hero-dash__dot { animation: dash-pulse 2s ease-in-out infinite; }
 @keyframes dash-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .35; } }
 


### PR DESCRIPTION
The AI-token bars in the hero dashboard only moved once on render. Now each bar gets an independent random height every ~1.1s with a smooth transform transition, keeping the panel alive. Reduced-motion safe.