### PR TITLE
feat: certification badge marquee (replaces per-profile chips)

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,18 +354,6 @@
                     <div class="member__skills">
                         <span>IAM</span><span>Zero Trust</span><span>AWS / GCP</span><span>Terraform</span><span>Kubernetes</span><span>Go</span>
                     </div>
-                    <div class="member__certs">
-                        <span class="member__certs-label">Certifications</span>
-                        <ul>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>TOGAF 9 Certified</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>CISSP</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>CCSP</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect &ndash; Professional</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Security &ndash; Specialty</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Google Professional Cloud Architect</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Okta Certified Professional</li>
-                        </ul>
-                    </div>
                     <a class="member__link" href="https://www.linkedin.com/in/yurii-kostiuk-778900ab/" target="_blank" rel="noopener">
                         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.1c0-1.7-.03-3.9-2.38-3.9-2.38 0-2.75 1.86-2.75 3.78V24h-4V8z"/></svg>
                         Connect on LinkedIn
@@ -383,17 +371,6 @@
                     <div class="member__skills">
                         <span>FinOps</span><span>FinOps for AI</span><span>Cost Governance</span><span>Multi-cloud</span><span>GreenOps</span><span>AWS</span>
                     </div>
-                    <div class="member__certs">
-                        <span class="member__certs-label">Certifications</span>
-                        <ul>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>FinOps Certified Practitioner</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>FinOps Certified Professional</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>FinOps Certified Engineer</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>FinOps for AI Certified</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>FinOps Certified Instructor</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Certified Cloud Practitioner</li>
-                        </ul>
-                    </div>
                     <a class="member__link" href="https://www.linkedin.com/in/tania-fedirko-9bb1a5136/" target="_blank" rel="noopener">
                         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.1c0-1.7-.03-3.9-2.38-3.9-2.38 0-2.75 1.86-2.75 3.78V24h-4V8z"/></svg>
                         Connect on LinkedIn
@@ -401,6 +378,33 @@
                 </div>
             </article>
 
+        </div>
+    </div>
+</section>
+
+<!-- ============ CERTIFICATIONS (marquee) ============ -->
+<section class="certs">
+    <div class="wrap">
+        <p class="proof__label">Certified across Kubernetes, security, cloud architecture &amp; FinOps</p>
+        <div class="marquee reveal">
+            <div class="marquee__track" id="certTrack">
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">CKA</text></svg><span class="cert__name">Certified Kubernetes Administrator</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#e8431c" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#e8431c" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">CKS</text></svg><span class="cert__name">Kubernetes Security Specialist</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#14110f" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#14110f" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">CKAD</text></svg><span class="cert__name">Kubernetes Application Developer</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="7.5" font-weight="700" fill="#14110f">TOGAF</text></svg><span class="cert__name">TOGAF 9 Certified</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#e8431c" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#e8431c" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="7.5" font-weight="700" fill="#14110f">CISSP</text></svg><span class="cert__name">CISSP</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#14110f" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#14110f" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">CCSP</text></svg><span class="cert__name">Certified Cloud Security Professional</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">SAA</text></svg><span class="cert__name">AWS Solutions Architect</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#e8431c" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#e8431c" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">SEC</text></svg><span class="cert__name">AWS Security &ndash; Specialty</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#14110f" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#14110f" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">GCP</text></svg><span class="cert__name">Google Professional Cloud Architect</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="8" font-weight="700" fill="#14110f">OKTA</text></svg><span class="cert__name">Okta Certified Professional</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#e8431c" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#e8431c" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">TF</text></svg><span class="cert__name">HashiCorp Terraform Associate</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#14110f" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#14110f" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="8" font-weight="700" fill="#14110f">FOCP</text></svg><span class="cert__name">FinOps Certified Practitioner</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">PRO</text></svg><span class="cert__name">FinOps Certified Professional</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#e8431c" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#e8431c" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">ENG</text></svg><span class="cert__name">FinOps Certified Engineer</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#14110f" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#14110f" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">AI</text></svg><span class="cert__name">FinOps for AI Certified</span></div>
+                <div class="cert"><svg class="cert__seal" viewBox="0 0 40 40" aria-hidden="true"><circle cx="20" cy="20" r="18.5" fill="none" stroke="#f4a91b" stroke-width="1" stroke-dasharray="2 3" opacity=".55"/><circle cx="20" cy="20" r="15.5" fill="#fff" stroke="#f4a91b" stroke-width="2"/><text x="20" y="23.5" text-anchor="middle" font-family="'Space Grotesk',sans-serif" font-size="9" font-weight="700" fill="#14110f">CCP</text></svg><span class="cert__name">AWS Certified Cloud Practitioner</span></div>
+            </div>
         </div>
     </div>
 </section>
@@ -590,6 +594,8 @@
     // seamless logo marquee (duplicate track content once)
     var track = document.getElementById('logoTrack');
     if (track) track.innerHTML += track.innerHTML;
+    var certTrack = document.getElementById('certTrack');
+    if (certTrack) certTrack.innerHTML += certTrack.innerHTML;
 
     if (!reduced) {
         // ---- magnetic buttons ----

--- a/style.css
+++ b/style.css
@@ -242,6 +242,14 @@ h1, h2, h3, h4 {
 .marquee__track .txt:hover { opacity: 1; }
 @keyframes scroll-x { from { transform: translateX(0); } to { transform: translateX(-50%); } }
 
+/* ---------- Certifications marquee ---------- */
+.certs { border-top: 1px solid rgba(20,17,15,.12); border-bottom: 1px solid rgba(20,17,15,.12); padding: 28px 0; background: var(--paper); }
+.certs .marquee__track { gap: 40px; animation-duration: 46s; }
+.cert { display: inline-flex; align-items: center; gap: 10px; white-space: nowrap; opacity: .82; transition: opacity .25s; }
+.cert:hover { opacity: 1; }
+.cert__seal { width: 40px; height: 40px; flex: 0 0 auto; }
+.cert__name { font-family: var(--font-head); font-weight: 500; font-size: 14px; color: var(--ink-soft); }
+
 /* ---------- Section heads ---------- */
 .shead { max-width: 720px; margin-bottom: 56px; }
 .shead h2 { font-size: clamp(30px, 4vw, 46px); margin-bottom: 18px; }
@@ -349,13 +357,6 @@ h1, h2, h3, h4 {
 .member p { color: var(--ink-soft); font-size: 15.5px; margin: 0 0 18px; }
 .member__skills { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 20px; }
 .member__skills span { font-size: 13px; font-family: var(--font-head); font-weight: 500; padding: 5px 12px; background: var(--paper-2); border-radius: 999px; border: 1px solid rgba(20,17,15,.18); }
-.member__certs { margin-bottom: 22px; }
-.member__certs-label { display: block; font-family: var(--font-head); font-size: 11px; font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: var(--muted); margin-bottom: 11px; }
-.member__certs ul { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
-.member__certs li { display: inline-flex; align-items: center; gap: 7px; font-family: var(--font-head); font-size: 12.5px; font-weight: 500; color: var(--ink-soft); background: var(--white); border: 1px solid rgba(20,17,15,.16); border-radius: 999px; padding: 6px 13px 6px 10px; transition: border-color .2s, transform .2s var(--ease); }
-.member__certs li:hover { border-color: var(--amber-deep); transform: translateY(-2px); }
-.member__certs li svg { width: 15px; height: 15px; flex: 0 0 auto; stroke: var(--amber-deep); fill: none; }
-
 .member__link { display: inline-flex; align-items: center; gap: 9px; font-family: var(--font-head); font-weight: 600; font-size: 15px; }
 .member__link svg { width: 18px; height: 18px; }
 .member__link:hover { color: var(--red); }


### PR DESCRIPTION
Removes the per-profile certification chips and adds one thin, continuously-scrolling strip of seal-style cert badges (like the client logo marquee). Adds Kubernetes (CKA/CKS/CKAD) and Terraform alongside security, cloud-architecture and FinOps credentials, shared across the team.