### PR TITLE
fix: balance team cards (remove Tania Cloud Practitioner)

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,6 @@
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Certified Kubernetes Administrator (CKA)</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>HashiCorp Terraform Associate</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect &ndash; Associate</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Certified Cloud Practitioner</li>
                         </ul>
                     </div>
                     <a class="member__link" href="https://www.linkedin.com/in/tania-fedirko-9bb1a5136/" target="_blank" rel="noopener">


### PR DESCRIPTION
Removes AWS Certified Cloud Practitioner from Tania so both cards have equal cert rows; combined with the bottom-pinned LinkedIn link, the cards match height with no gap above Yurii's link.