### PR TITLE
style: remove long dashes from site copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>document.documentElement.className += ' js';</script>
-    <title>IT-RAT — Secure AI, Cloud Security &amp; FinOps for Enterprise</title>
-    <meta name="description" content="IT-RAT is a boutique cloud consultancy. We help enterprises adopt AI across cloud, FinOps and security — and keep that full-scale AI rollout secure, cost-governed and compliant. Zero Trust, IAM, FinOps for AI and platform engineering across AWS and GCP.">
+    <title>IT-RAT: Secure AI, Cloud Security &amp; FinOps for Enterprise</title>
+    <meta name="description" content="IT-RAT is a boutique cloud consultancy. We help enterprises adopt AI across cloud, FinOps and security, and keep that full-scale AI rollout secure, cost-governed and compliant. Zero Trust, IAM, FinOps for AI and platform engineering across AWS and GCP.">
     <meta name="keywords" content="Secure AI, AI Governance, FinOps for AI, LLM, GenAI, AI workloads, Cloud Security, IAM, Zero Trust, FinOps, Cloud Cost Optimization, DevSecOps, AWS, GCP, Kubernetes, Terraform">
     <link rel="shortcut icon" type="image/png" href="favicon.png">
-    <meta property="og:title" content="IT-RAT — Secure, Governed AI for Enterprise">
-    <meta property="og:description" content="Adopt AI everywhere — kept secure, cost-governed and compliant. Senior cloud security, FinOps and AI architecture for complex, high-stakes projects.">
+    <meta property="og:title" content="IT-RAT: Secure, Governed AI for Enterprise">
+    <meta property="og:description" content="Adopt AI everywhere, kept secure, cost-governed and compliant. Senior cloud security, FinOps and AI architecture for complex, high-stakes projects.">
     <meta property="og:type" content="website">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -48,7 +48,7 @@
         <div class="hero__copy reveal">
             <span class="eyebrow">AI Adoption · Cloud Security · FinOps</span>
             <h1>Scale AI safely.<br><span class="hl">Control</span> the spend.</h1>
-            <p class="lede">IT-RAT is a boutique cloud consultancy for complex, high-stakes projects. We put AI to work across cloud platforms, FinOps practices and security — frontier AI and LLM workloads, identity and Zero Trust, cost governance — and keep that full-scale rollout secure, compliant and under control. Senior, hands-on architects taking on the hardest problems in modern cloud, security and AI.</p>
+            <p class="lede">IT-RAT is a boutique cloud consultancy for complex, high-stakes projects. We put AI to work across cloud platforms, FinOps practices and security: frontier AI and LLM workloads, identity and Zero Trust, cost governance. Then we keep that full-scale rollout secure, compliant and under control. Senior, hands-on architects taking on the hardest problems in modern cloud, security and AI.</p>
             <div class="hero__cta">
                 <a class="btn btn--primary" href="#contact">Book a discovery call <span class="arr">&rarr;</span></a>
                 <a class="btn btn--ghost" href="#services">What we do</a>
@@ -66,7 +66,7 @@
             <span class="hero__badge hero__badge--2">Zero Trust</span>
             <svg class="hero__panel" viewBox="0 0 480 400" role="img" xmlns="http://www.w3.org/2000/svg"
                  aria-label="AI cost and security dashboard: cloud and AI spend down 30%, Zero Trust security, token usage guardrailed.">
-                <title>AI under control — cost, security and token governance dashboard</title>
+                <title>AI under control: cost, security and token governance dashboard</title>
 
                 <!-- header -->
                 <text x="22" y="34" font-family="'Space Grotesk', sans-serif" font-size="19" font-weight="700" fill="#14110f">AI under control</text>
@@ -79,7 +79,7 @@
                 <!-- cost card -->
                 <rect x="20" y="58" width="440" height="172" rx="14" fill="#ffffff" stroke="#14110f"/>
                 <text x="40" y="92" font-family="'Space Grotesk', sans-serif" font-size="12" font-weight="600" letter-spacing="1.5" fill="#8a8175">CLOUD + AI SPEND</text>
-                <text id="costNum" x="40" y="128" font-family="'Space Grotesk', sans-serif" font-size="34" font-weight="700" fill="#d98c00">&#8722;30%</text>
+                <text id="costNum" x="40" y="128" font-family="'Space Grotesk', sans-serif" font-size="34" font-weight="700" fill="#d98c00">-30%</text>
                 <text x="150" y="128" font-family="'Inter', sans-serif" font-size="13" fill="#8a8175">this quarter</text>
                 <!-- chart -->
                 <path class="hero-dash__area" d="M44,150 L116,166 L188,146 L260,178 L332,172 L404,194 L440,202 L440,212 L44,212 Z" fill="#f4a91b" fill-opacity="0.16"/>
@@ -151,7 +151,7 @@
         <div class="shead">
             <span class="eyebrow">The problem</span>
             <h2>Cloud got expensive and exposed at the same time.</h2>
-            <p class="lede">Spend climbs faster than anyone forecast, AI workloads add a brand-new line item nobody owns, and every new service widens the attack surface. Most teams are firefighting both — without the architecture to fix the root cause.</p>
+            <p class="lede">Spend climbs faster than anyone forecast, AI workloads add a brand-new line item nobody owns, and every new service widens the attack surface. Most teams are firefighting both, without the architecture to fix the root cause.</p>
         </div>
         <div class="pain__grid">
             <div class="pain__card reveal">
@@ -178,8 +178,8 @@
     <div class="wrap">
         <div class="shead">
             <span class="eyebrow">What we do</span>
-            <h2>Cloud security and FinOps — with AI through all of it.</h2>
-            <p class="lede">We pair deep cloud-security architecture with hands-on FinOps governance, and we weave AI into every layer — so adopting it makes you faster without making you less safe, compliant or cost-efficient.</p>
+            <h2>Cloud security and FinOps, with AI through all of it.</h2>
+            <p class="lede">We pair deep cloud-security architecture with hands-on FinOps governance, and we weave AI into every layer, so adopting it makes you faster without making you less safe, compliant or cost-efficient.</p>
         </div>
         <div class="svc__grid">
 
@@ -236,7 +236,7 @@
                     <svg viewBox="0 0 24 24" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M19 5l-2 2M7 17l-2 2"/></svg>
                 </div>
                 <h3>Advisory &amp; Architecture Reviews</h3>
-                <p>A senior, independent read on where your cloud stands — and a roadmap to fix it.</p>
+                <p>A senior, independent read on where your cloud stands, plus a roadmap to fix it.</p>
                 <ul>
                     <li><svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l4 4 10-10"/></svg>Security &amp; cost posture assessments</li>
                     <li><svg viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l4 4 10-10"/></svg>Multi-year cloud strategy &amp; reference standards</li>
@@ -256,8 +256,8 @@
             <div class="aiband__inner">
                 <div>
                     <span class="eyebrow">AI, under control</span>
-                    <h2>Full-scale AI adoption — kept under control.</h2>
-                    <p>We're putting AI to work across everything we do — cloud platforms, FinOps practices and security. The hard part isn't adopting AI, it's governing a full-scale rollout. We make AI secure, cost-controlled and compliant by design: from LLM APIs and token-based usage to cloud-native AI services and autonomous agents.</p>
+                    <h2>Full-scale AI adoption, kept under control.</h2>
+                    <p>We're putting AI to work across everything we do: cloud platforms, FinOps practices and security. The hard part isn't adopting AI, it's governing a full-scale rollout. We make AI secure, cost-controlled and compliant by design: from LLM APIs and token-based usage to cloud-native AI services and autonomous agents.</p>
                 </div>
                 <div class="aiband__stats">
                     <div class="stat">
@@ -346,7 +346,7 @@
         <div class="shead center">
             <span class="eyebrow">Who you work with</span>
             <h2>Senior architects. No hand-offs.</h2>
-            <p class="lede" style="margin:0 auto;">You work directly with the people who do this at enterprise scale every day — not a layer of account managers.</p>
+            <p class="lede" style="margin:0 auto;">You work directly with the people who do this at enterprise scale every day, not a layer of account managers.</p>
         </div>
         <div class="team__grid">
 
@@ -356,7 +356,7 @@
                     <span class="member__role">Co-founder · Cloud Security &amp; IAM</span>
                     <h3>Yurii Kostiuk</h3>
                     <p class="where">Lead Security Architect, PETRONAS · ex-Cloud Native Architect, Okta</p>
-                    <p>IAM solutions architect and cloud security consultant. Yurii defines enterprise-wide security strategy and designs secure, scalable architectures across hybrid and cloud-native environments — Zero Trust, identity, DevSecOps and platform resilience on AWS and GCP.</p>
+                    <p>IAM solutions architect and cloud security consultant. Yurii defines enterprise-wide security strategy and designs secure, scalable architectures across hybrid and cloud-native environments: Zero Trust, identity, DevSecOps and platform resilience on AWS and GCP.</p>
                     <div class="member__skills">
                         <span>IAM</span><span>Zero Trust</span><span>AWS / GCP</span><span>Terraform</span><span>Kubernetes</span><span>Go</span>
                     </div>
@@ -368,8 +368,8 @@
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>CCSP</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Certified Kubernetes Administrator (CKA)</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Certified Kubernetes Security Specialist (CKS)</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect &ndash; Professional</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Security &ndash; Specialty</li>
+                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect Professional</li>
+                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Security Specialty</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Google Professional Cloud Architect</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Okta Certified Professional</li>
                         </ul>
@@ -387,7 +387,7 @@
                     <span class="member__role">Co-founder · FinOps &amp; Cost Governance</span>
                     <h3>Tania Fedirko</h3>
                     <p class="where">Principal FinOps Architect, NatWest Group · AWS Community Builder</p>
-                    <p>FinOps expert in cloud financial governance, cost optimization and multi-cloud strategy. Tania aligns engineering, finance and business across cloud, Kubernetes and AI workloads — applying FinOps best practices to LLM APIs and token-based usage while keeping things sustainable and scalable.</p>
+                    <p>FinOps expert in cloud financial governance, cost optimization and multi-cloud strategy. Tania aligns engineering, finance and business across cloud, Kubernetes and AI workloads, applying FinOps best practices to LLM APIs and token-based usage while keeping things sustainable and scalable.</p>
                     <div class="member__skills">
                         <span>FinOps</span><span>FinOps for AI</span><span>Cost Governance</span><span>Multi-cloud</span><span>GreenOps</span><span>AWS</span>
                     </div>
@@ -402,7 +402,7 @@
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Cloud Sustainability (GreenOps)</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>Certified Kubernetes Administrator (CKA)</li>
                             <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>HashiCorp Terraform Associate</li>
-                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect &ndash; Associate</li>
+                            <li><svg viewBox="0 0 24 24" fill="none" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="6"/><path d="M9 9l2 2 4-4"/><path d="M8.5 14.5 7 22l5-2.5L17 22l-1.5-7.5"/></svg>AWS Solutions Architect Associate</li>
                         </ul>
                     </div>
                     <a class="member__link" href="https://www.linkedin.com/in/tania-fedirko-9bb1a5136/" target="_blank" rel="noopener">
@@ -427,11 +427,11 @@
         <div class="steps">
             <div class="step reveal">
                 <h3>Assess</h3>
-                <p>A focused review of your cloud security posture and cost structure. You get a clear, prioritized picture of risk and waste — usually within weeks.</p>
+                <p>A focused review of your cloud security posture and cost structure. You get a clear, prioritized picture of risk and waste, usually within weeks.</p>
             </div>
             <div class="step reveal">
                 <h3>Architect</h3>
-                <p>We design the target state: identity model, guardrails, FinOps operating model and reference architectures — mapped to your compliance obligations.</p>
+                <p>We design the target state: identity model, guardrails, FinOps operating model and reference architectures, mapped to your compliance obligations.</p>
             </div>
             <div class="step reveal">
                 <h3>Embed</h3>
@@ -447,7 +447,7 @@
         <div class="reveal">
             <span class="eyebrow">Get started</span>
             <h2>Let's make your cloud safer and cheaper.</h2>
-            <p>Tell us where it hurts — runaway spend, a looming audit, an identity mess, or an AI rollout nobody's governing. We'll come back with a concrete first step.</p>
+            <p>Tell us where it hurts: runaway spend, a looming audit, an identity mess, or an AI rollout nobody's governing. We'll come back with a concrete first step.</p>
             <div class="cta__meta">
                 <a href="mailto:itratmail@gmail.com">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6 9-6"/></svg>
@@ -488,7 +488,7 @@
         <div class="footer__top">
             <div>
                 <a class="brand" href="#top"><img src="img/29.png" alt="IT-RAT logo"><span class="brand__txt">IT<i>-RAT</i></span></a>
-                <p class="footer__tag">Boutique cloud consultancy for enterprise — adopting AI across cloud, FinOps and security, and keeping it secure, cost-governed and compliant.</p>
+                <p class="footer__tag">Boutique cloud consultancy for enterprise. We adopt AI across cloud, FinOps and security, and keep it secure, cost-governed and compliant.</p>
             </div>
             <div class="footer__social">
                 <a href="https://www.linkedin.com/in/it-rat-117084146/" target="_blank" rel="noopener" aria-label="LinkedIn">
@@ -534,7 +534,7 @@
         if (e.target.tagName === 'A') nav.classList.remove('open');
     });
 
-    // scroll reveal (rect-based — fires reliably on real and programmatic scroll)
+    // scroll reveal (rect-based, fires reliably on real and programmatic scroll)
     var revealEls = [].slice.call(document.querySelectorAll('.reveal'));
     var revealCheck = function () {
         var vh = window.innerHeight || document.documentElement.clientHeight;
@@ -567,7 +567,7 @@
             var name = (document.getElementById('name').value || '').trim();
             var email = (document.getElementById('email').value || '').trim();
             var msg = (document.getElementById('message').value || '').trim();
-            var subject = encodeURIComponent('New enquiry from ' + (name || 'website') + ' — IT-RAT');
+            var subject = encodeURIComponent('IT-RAT enquiry from ' + (name || 'website'));
             var body = encodeURIComponent('Name: ' + name + '\nEmail: ' + email + '\n\n' + msg);
             var note = document.getElementById('formNote');
             if (note) note.textContent = 'Opening your email app to send…';
@@ -597,11 +597,11 @@
     var costEl = document.getElementById('costNum');
     if (costEl && !reduced) {
         var n = 0;
-        costEl.textContent = '−0%';
+        costEl.textContent = '-0%';
         var ci = setInterval(function () {
             n += 2;
             if (n >= 30) { n = 30; clearInterval(ci); }
-            costEl.textContent = '−' + n + '%';
+            costEl.textContent = '-' + n + '%';
         }, 45);
     }
 


### PR DESCRIPTION
Rewrites sentences that used spaced em/en dashes so they read naturally without them (commas, colons, full stops). Short hyphens are kept. Cert names drop the en dash; the cost figure uses a plain hyphen. Verified no — or – remains in index.html.