### PR TITLE
fix(css): restore team photo aspect ratio

### DIFF
--- a/style.css
+++ b/style.css
@@ -343,7 +343,7 @@ h1, h2, h3, h4 {
 }
 .member:hover { transform: translateY(-6px); box-shadow: var(--shadow); }
 .member__media { background: var(--paper); border-bottom: 1px solid var(--ink); display: grid; place-items: center; padding: 20px; }
-.member__media img { width: 240px; max-width: 80%; }
+.member__media img { width: 240px; max-width: 80%; height: auto; }
 .member__body { padding: 30px 32px 34px; display: flex; flex-direction: column; flex: 1; }
 .member__role { font-family: var(--font-head); font-size: 13px; font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: var(--red); }
 .member h3 { font-size: 27px; margin: 8px 0 6px; }


### PR DESCRIPTION
The width/height attributes added for CLS made the team photos render 240×521 (stretched tall) because `.member__media img` set only `width`; the `height` attribute was then applied literally. Add `height:auto` so the intrinsic aspect ratio is preserved (renders ~240×243, as before) while keeping the CLS/no-layout-shift benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)