### PR TITLE
style: double team photo size

### DIFF
--- a/style.css
+++ b/style.css
@@ -343,7 +343,7 @@ h1, h2, h3, h4 {
 }
 .member:hover { transform: translateY(-6px); box-shadow: var(--shadow); }
 .member__media { background: var(--paper); border-bottom: 1px solid var(--ink); display: grid; place-items: center; padding: 20px; }
-.member__media img { width: 240px; max-width: 80%; height: auto; }
+.member__media img { width: 480px; max-width: 100%; height: auto; }
 .member__body { padding: 30px 32px 34px; display: flex; flex-direction: column; flex: 1; }
 .member__role { font-family: var(--font-head); font-size: 13px; font-weight: 600; letter-spacing: .12em; text-transform: uppercase; color: var(--red); }
 .member h3 { font-size: 27px; margin: 8px 0 6px; }


### PR DESCRIPTION
Team illustrations looked too small in their frames after the aspect-ratio fix. Double the displayed width (240px → 480px, ~2×) and raise `max-width` to 100% so the larger size renders; still scales down responsively on narrow screens (no overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)