### PR TITLE
feat: add Products section (flagship products + agent governance stack)

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         </a>
         <nav class="nav__links" id="navlinks">
             <a href="#services">Services</a>
+            <a href="products/">Products</a>
             <a href="#ai">AI</a>
             <a href="#capabilities">Capabilities</a>
             <a href="#team">Team</a>
@@ -285,6 +286,29 @@
                         <div class="big">Govern</div>
                         <div class="lbl">Policy &amp; compliance enforced for every model</div>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- ============ PRODUCTS TEASER ============ -->
+<section class="section section--tight" id="products">
+    <div class="wrap">
+        <div class="pband reveal">
+            <div class="pband__inner">
+                <div>
+                    <span class="eyebrow">Products</span>
+                    <h2>We build the tooling we recommend.</h2>
+                    <p>Advisory backed by working software: a runtime FinOps gateway for AI agents, a local-first
+                    memory layer, and a six-service governance stack. Built and run by the same architects
+                    you work with.</p>
+                    <a class="btn btn--primary" href="products/">Explore the products <span class="arr">&rarr;</span></a>
+                </div>
+                <div class="pband__cards">
+                    <div class="mini"><b>TokenFuse</b><span>runtime spend kill-switch</span></div>
+                    <div class="mini"><b>Engram</b><span>the SQLite of agent memory</span></div>
+                    <div class="mini"><b>Governance stack</b><span>6 services · one event contract</span></div>
                 </div>
             </div>
         </div>

--- a/products/index.html
+++ b/products/index.html
@@ -1,0 +1,824 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>document.documentElement.className += ' js';</script>
+    <title>IT-RAT Products: TokenFuse, Engram &amp; the Agent Governance Stack</title>
+    <meta name="description" content="The software behind the consultancy: TokenFuse, a runtime FinOps kill-switch for AI agents; Engram, a local-first memory layer; SphereOS, on-device personal AI; and a six-service agent governance stack covering identity, cryptography, policy, quality and safety rehearsal.">
+    <meta name="keywords" content="TokenFuse, Engram, SphereOS, AI agent governance, FinOps for AI, LLM budget enforcement, agent security, AI spend kill-switch, agent memory, ITDR, CBOM, post-quantum">
+    <link rel="shortcut icon" type="image/png" href="/favicon.png">
+    <link rel="canonical" href="https://it-rat.github.io/products/">
+    <meta property="og:title" content="IT-RAT Products: the tooling we recommend, built in-house">
+    <meta property="og:description" content="A runtime FinOps gateway for AI agents, a local-first memory layer, and a six-service governance stack. Built and run by the same architects you work with.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://it-rat.github.io/products/">
+    <meta property="og:image" content="https://it-rat.github.io/img/og-card.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="IT-RAT Products: the tooling we recommend, built in-house">
+    <meta name="twitter:description" content="A runtime FinOps gateway for AI agents, a local-first memory layer, and a six-service governance stack. Built and run by the same architects you work with.">
+    <meta name="twitter:image" content="https://it-rat.github.io/img/og-card.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="/style.css">
+</head>
+<body>
+
+<div class="scrollbar" id="scrollbar"></div>
+
+<!-- ============ NAV ============ -->
+<header class="nav" id="nav">
+    <div class="wrap nav__inner">
+        <a class="brand" href="/" aria-label="IT-RAT home">
+            <img src="/img/29.png" alt="IT-RAT logo"><span class="brand__txt">IT<i>-RAT</i></span>
+        </a>
+        <nav class="nav__links" id="navlinks">
+            <a href="/#services">Services</a>
+            <a href="/products/" aria-current="page">Products</a>
+            <a href="/#ai">AI</a>
+            <a href="/#capabilities">Capabilities</a>
+            <a href="/#team">Team</a>
+            <a class="btn btn--primary nav__cta" href="/#contact">Book a call</a>
+        </nav>
+        <button class="nav__toggle" id="navtoggle" aria-label="Toggle menu" aria-expanded="false">
+            <span></span><span></span><span></span>
+        </button>
+    </div>
+</header>
+
+<main id="top">
+
+<!-- ============ PAGE HERO ============ -->
+<section class="phero">
+    <div class="wrap">
+        <div class="reveal">
+            <span class="eyebrow">Products · Built in-house</span>
+            <h1>We build the <span class="hl">tooling</span> we recommend.</h1>
+            <p class="lede">Advisory backed by working software. Three flagship products put FinOps and
+            security guardrails around real AI workloads, and a six-service governance stack keeps a fleet
+            of agents secure, cost-governed and auditable. Built and run by the same architects you work with.</p>
+        </div>
+    </div>
+</section>
+
+<!-- ============ TABS + GRIDS ============ -->
+<section class="section section--tight">
+    <div class="wrap">
+
+        <div class="ptabs reveal" role="tablist" id="tabbar">
+            <button class="ptab" role="tab" aria-selected="true" data-tab="products">Flagship products<span class="n">3</span></button>
+            <button class="ptab" role="tab" aria-selected="false" data-tab="stack">Agent governance stack<span class="n">6</span></button>
+        </div>
+
+        <!-- ---- TAB 1: flagship products ---- -->
+        <div id="tab-products" class="tabpane">
+            <div class="pgrid">
+
+                <button class="pcard pcard--red reveal" data-detail="tokenfuse">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M13 2 4 14h6l-1 8 9-12h-6l1-8z"/></svg></span>
+                    <span class="pcard__plane">Runtime FinOps enforcement</span>
+                    <h3>TokenFuse</h3>
+                    <p>The runtime spend kill-switch for AI agents. A drop-in proxy that enforces budgets in real
+                    time and cuts the circuit instead of reporting the damage after the fact.</p>
+                    <span class="pcard__meta"><span class="chip">Rust</span><span class="chip">v0.3.0</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--amber reveal" data-detail="engram">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><ellipse cx="12" cy="6" rx="7.5" ry="3"/><path d="M4.5 6v12c0 1.7 3.4 3 7.5 3s7.5-1.3 7.5-3V6"/><path d="M4.5 12c0 1.7 3.4 3 7.5 3s7.5-1.3 7.5-3"/></svg></span>
+                    <span class="pcard__plane">Memory layer for agents</span>
+                    <h3>Engram</h3>
+                    <p>The SQLite of agent memory: an embeddable, local-first store with episodic and semantic
+                    memory, importance decay, and provenance for every recall.</p>
+                    <span class="pcard__meta"><span class="chip">Python</span><span class="chip">v2.2.0</span><span class="chip chip--public">On PyPI</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--ink reveal" data-detail="sphereos">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><ellipse cx="12" cy="12" rx="9" ry="3.6"/><path d="M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg></span>
+                    <span class="pcard__plane">Personal AI · on-device</span>
+                    <h3>SphereOS</h3>
+                    <p>Personal life intelligence, fully on-device. Twelve life domains, each with its own AI agent
+                    and its own Engram memory. No account, no server.</p>
+                    <span class="pcard__meta"><span class="chip">Swift 6</span><span class="chip">iOS 17+</span><span class="chip chip--status">In development</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+            </div>
+        </div>
+
+        <!-- ---- TAB 2: governance stack ---- -->
+        <div id="tab-stack" class="tabpane" hidden>
+
+            <div class="stack-note reveal">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l8 4v5c0 5-3.4 8-8 9-4.6-1-8-4-8-9V7l8-4z"/><path d="M9 12l2 2 4-4"/></svg>
+                <div><b>Defensive by design.</b> Every service in this stack governs, observes or cost-controls
+                <b>your own</b> agents. Nothing here is offensive tooling: even the rehearsal scenarios are
+                fire drills run against your own gateway, never against external systems.</div>
+            </div>
+
+            <div class="diagram-card reveal" style="margin-bottom:28px;">
+                <svg class="dg" viewBox="0 0 960 540" role="img" aria-label="Agent governance stack architecture: TokenFuse enforces between agents and LLM providers, Wardryx decides policy, Mockryx rehearses guardrails, and events flow to Idryx, Verdryx and Qryx over one shared contract.">
+                    <defs>
+                        <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#14110f"/></marker>
+                        <marker id="arr-red" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#e8431c"/></marker>
+                    </defs>
+
+                    <g data-node="agents">
+                        <rect class="box box--soft hlring" x="40" y="46" width="190" height="74" rx="10"/>
+                        <text class="lbl" x="135" y="78" text-anchor="middle">Your AI agents</text>
+                        <text class="lbl lbl--sub" x="135" y="98" text-anchor="middle">apps · pipelines · copilots</text>
+                    </g>
+                    <path class="flow" d="M230 83 H364"/>
+                    <text class="lbl lbl--sub" x="297" y="72" text-anchor="middle">one base-URL swap</text>
+
+                    <g data-node="tokenfuse">
+                        <rect class="box box--amber hlring" x="368" y="38" width="224" height="90" rx="10"/>
+                        <text class="lbl" x="480" y="70" text-anchor="middle">TokenFuse</text>
+                        <text class="lbl lbl--sub" x="480" y="90" text-anchor="middle">gateway · enforcement point</text>
+                        <text class="lbl lbl--sub" x="480" y="107" text-anchor="middle">budgets · Breaker · DLP</text>
+                    </g>
+                    <path class="flow" d="M592 83 H726"/>
+                    <g data-node="providers">
+                        <rect class="box box--soft hlring" x="730" y="46" width="190" height="74" rx="10"/>
+                        <text class="lbl" x="825" y="78" text-anchor="middle">LLM providers</text>
+                        <text class="lbl lbl--sub" x="825" y="98" text-anchor="middle">Anthropic · OpenAI · …</text>
+                    </g>
+
+                    <g data-node="wardryx">
+                        <rect class="box hlring" x="368" y="188" width="224" height="76" rx="10"/>
+                        <text class="lbl" x="480" y="218" text-anchor="middle">Wardryx</text>
+                        <text class="lbl lbl--sub" x="480" y="238" text-anchor="middle">policy decisions · allow / deny / hold</text>
+                    </g>
+                    <path class="flow" d="M470 128 V184"/>
+                    <path class="flow" d="M490 184 V128"/>
+                    <text class="lbl lbl--sub" x="604" y="162" text-anchor="start">asked before every call,</text>
+                    <text class="lbl lbl--sub" x="604" y="178" text-anchor="start">deterministic, no LLM in the loop</text>
+
+                    <g data-node="mockryx">
+                        <rect class="box hlring" x="40" y="188" width="190" height="76" rx="10"/>
+                        <text class="lbl" x="135" y="218" text-anchor="middle">Mockryx</text>
+                        <text class="lbl lbl--sub" x="135" y="238" text-anchor="middle">guardrail fire drills, pre-prod</text>
+                    </g>
+                    <path class="flow flow--dash flow--red" d="M180 184 C230 150 300 128 368 112"/>
+
+                    <rect x="40" y="310" width="880" height="34" rx="8" fill="#efe8dc" stroke="#14110f" stroke-width="1.5"/>
+                    <text class="buslbl" x="480" y="332" text-anchor="middle">agent-event stream · NDJSON · one shared envelope</text>
+                    <path class="flow" d="M480 264 V306"/>
+
+                    <g data-node="idryx">
+                        <rect class="box hlring" x="112" y="392" width="220" height="76" rx="10"/>
+                        <text class="lbl" x="222" y="422" text-anchor="middle">Idryx</text>
+                        <text class="lbl lbl--sub" x="222" y="442" text-anchor="middle">identity graph · ITDR + NHI</text>
+                    </g>
+                    <path class="flow" d="M222 344 V388"/>
+
+                    <g data-node="verdryx">
+                        <rect class="box hlring" x="370" y="392" width="220" height="76" rx="10"/>
+                        <text class="lbl" x="480" y="422" text-anchor="middle">Verdryx</text>
+                        <text class="lbl lbl--sub" x="480" y="442" text-anchor="middle">quality · cost-per-outcome</text>
+                    </g>
+                    <path class="flow" d="M480 344 V388"/>
+
+                    <g data-node="qryx">
+                        <rect class="box hlring" x="628" y="392" width="220" height="76" rx="10"/>
+                        <text class="lbl" x="738" y="422" text-anchor="middle">Qryx</text>
+                        <text class="lbl lbl--sub" x="738" y="442" text-anchor="middle">crypto inventory · CBOM · PQC</text>
+                    </g>
+                    <path class="flow flow--dash" d="M738 388 V344"/>
+
+                    <g data-node="contract">
+                        <rect class="box box--ink hlring" x="112" y="496" width="736" height="34" rx="8"/>
+                        <text class="lbl lbl--inv" x="480" y="518" text-anchor="middle" font-size="13">agent-stack-go · the one shared, public contract · v0.1.0</text>
+                    </g>
+                </svg>
+                <div class="cap">The stack around one enforcement point: decide, enforce, observe, evaluate, rehearse</div>
+            </div>
+
+            <div class="pgrid pgrid--svc">
+
+                <button class="pcard pcard--red reveal" data-detail="idryx">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="3.5"/><path d="M5 20c1-3.8 3.6-6 7-6s6 2.2 7 6"/><circle cx="19" cy="5" r="2.2"/><circle cx="5" cy="5" r="2.2"/></svg></span>
+                    <span class="pcard__plane">Identity plane</span>
+                    <h3>Idryx</h3>
+                    <p>The Identity Security Graph: humans, service accounts, keys and AI agents in one graph,
+                    with deterministic detectors. Read-only by design.</p>
+                    <span class="pcard__meta"><span class="chip">Go</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--amber reveal" data-detail="qryx">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/><circle cx="12" cy="15" r="1.6"/></svg></span>
+                    <span class="pcard__plane">Cryptography plane</span>
+                    <h3>Qryx</h3>
+                    <p>The Cryptography Security Graph: every use of crypto across code, binaries, containers, TLS
+                    and KMS, scored for post-quantum risk. CBOM out.</p>
+                    <span class="pcard__meta"><span class="chip">Go</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--ink reveal" data-detail="wardryx">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v18M5 7h14"/><path d="M5 7l-2.5 6a3.5 3.5 0 0 0 7 0L7 7M19 7l-2.5 6a3.5 3.5 0 0 0 7 0L21 7"/></svg></span>
+                    <span class="pcard__plane">Policy plane</span>
+                    <h3>Wardryx</h3>
+                    <p>The policy decision point: allow, deny, or hold with a signed human approval.
+                    Deterministic, no LLM in the loop, explainable to an auditor.</p>
+                    <span class="pcard__meta"><span class="chip">Go</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--amber reveal" data-detail="verdryx">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 19h16"/><path d="M4 19V9m5.3 10v-6m5.4 6V6m5.3 13v-9"/><path d="M4 8l6-3 5 4 5-5"/></svg></span>
+                    <span class="pcard__plane">Quality plane</span>
+                    <h3>Verdryx</h3>
+                    <p>The quality denominator under AI spend: grades agent outputs over TokenFuse traces
+                    and reports cost-per-outcome, not cost-per-call.</p>
+                    <span class="pcard__meta"><span class="chip">Python</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--red reveal" data-detail="mockryx">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3c2 3-1 4.5-1 7a3.5 3.5 0 0 0 7 .5C19.5 14 21 16 19 19a8 8 0 0 1-14-5c0-4 4-6 7-11z"/></svg></span>
+                    <span class="pcard__plane">Rehearsal plane</span>
+                    <h3>Mockryx</h3>
+                    <p>Fire drills for your guardrails: replays hostile scenarios against your own gateway
+                    before production, and gates CI on the result.</p>
+                    <span class="pcard__meta"><span class="chip">Go</span><span class="chip chip--status">Private beta</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+                <button class="pcard pcard--ink reveal" data-detail="contract">
+                    <span class="pcard__icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M8 4c-2 0-3 1-3 3v2c0 1.5-1 2-2 2 1 0 2 .5 2 2v4c0 2 1 3 3 3M16 4c2 0 3 1 3 3v2c0 1.5 1 2 2 2-1 0-2 .5-2 2v4c0 2-1 3-3 3"/></svg></span>
+                    <span class="pcard__plane">Shared contract · public</span>
+                    <h3>agent-stack-go</h3>
+                    <p>The one public repo: a stdlib-only Go module with the event envelope and Agent Passport
+                    types every service imports. Producer and consumer never drift.</p>
+                    <span class="pcard__meta"><span class="chip">Go</span><span class="chip">v0.1.0</span><span class="chip chip--public">Public</span></span>
+                    <span class="pcard__more">Read more <span class="arr">&rarr;</span></span>
+                </button>
+
+            </div>
+        </div>
+
+        <!-- ---- DETAILS ---- -->
+        <div class="pdetail" id="detail-tokenfuse" data-parent="products">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Flagship · Runtime FinOps enforcement</span>
+                    <h2>TokenFuse</h2>
+                    <p class="lede">A drop-in reverse proxy between your AI agents and LLM providers. One base-URL swap,
+                    and every call passes through real-time budget enforcement. When an agent runs away, the Breaker
+                    cuts the circuit with HTTP 402 at the moment of breach, not in next month's invoice review.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Per-run and hierarchical budgets enforced in real time</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Runaway-loop, spend-spike and fan-out detection with live incidents</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>FinOps-native reporting: FOCUS-format export, savings, cost-per-outcome tags</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Out-of-band mobile kill-switch, signed in the Secure Enclave (iPhone + Watch)</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Compliance reports mapped to OWASP Agentic Top 10, NIST 800-53, EU AI Act, SOC 2</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>High-availability Raft cluster and a hosted control plane with dashboard</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Rust</span><span class="chip">Raft HA</span><span class="chip">eBPF Radar</span>
+                        <span class="chip">Parquet + SQL</span><span class="chip">OpenTelemetry</span><span class="chip">JS / Python SDK</span>
+                    </div>
+                    <div class="pdetail__links">
+                        <span class="chip chip--status">Private beta</span>
+                        <span class="private-note">Early access on request via the <a href="/#contact">contact form</a></span>
+                    </div>
+                </div>
+                <div class="diagram-card">
+                    <svg class="dg" viewBox="0 0 520 360" role="img" aria-label="TokenFuse enforcement flow: agent calls pass a budget check; on breach the Breaker returns HTTP 402 and the circuit is cut.">
+                        <defs>
+                            <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#14110f"/></marker>
+                            <marker id="arr2r" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#e8431c"/></marker>
+                        </defs>
+                        <rect class="box box--soft" x="20" y="40" width="130" height="64" rx="10"/>
+                        <text class="lbl" x="85" y="68" text-anchor="middle" font-size="14">AI agent</text>
+                        <text class="lbl lbl--sub" x="85" y="86" text-anchor="middle">any framework</text>
+
+                        <path d="M150 72 H190" stroke="#14110f" stroke-width="1.6" fill="none" marker-end="url(#arr2)"/>
+
+                        <rect class="box box--amber" x="194" y="28" width="140" height="88" rx="10"/>
+                        <text class="lbl" x="264" y="60" text-anchor="middle" font-size="15">TokenFuse</text>
+                        <text class="lbl lbl--sub" x="264" y="78" text-anchor="middle">budget check</text>
+                        <text class="lbl lbl--sub" x="264" y="94" text-anchor="middle">per call, in-line</text>
+
+                        <path d="M334 72 H374" stroke="#14110f" stroke-width="1.6" fill="none" marker-end="url(#arr2)"/>
+                        <text class="lbl lbl--tag" x="354" y="18" text-anchor="middle">ALLOW</text>
+                        <path d="M354 24 V60" stroke="#d98c00" stroke-width="1" fill="none" stroke-dasharray="3 3"/>
+
+                        <rect class="box box--soft" x="378" y="40" width="122" height="64" rx="10"/>
+                        <text class="lbl" x="439" y="68" text-anchor="middle" font-size="14">Provider</text>
+                        <text class="lbl lbl--sub" x="439" y="86" text-anchor="middle">LLM API</text>
+
+                        <path d="M264 116 V168" stroke="#e8431c" stroke-width="1.8" fill="none" marker-end="url(#arr2r)" stroke-dasharray="5 5"/>
+                        <rect x="164" y="172" width="200" height="58" rx="10" fill="#e8431c"/>
+                        <text x="264" y="197" text-anchor="middle" fill="#fff" font-size="14" font-weight="600">Breaker · HTTP 402</text>
+                        <text x="264" y="216" text-anchor="middle" fill="#ffd9cf" font-size="11.5">budget exhausted, circuit cut</text>
+
+                        <text class="lbl lbl--sub" x="20" y="278">run budget</text>
+                        <rect x="20" y="288" width="480" height="16" rx="8" fill="#efe8dc" stroke="#14110f" stroke-width="1.2"/>
+                        <rect x="22" y="290" width="360" height="12" rx="6" fill="#f4a91b"/>
+                        <rect x="382" y="290" width="70" height="12" rx="6" fill="#e8431c"/>
+                        <text class="lbl lbl--sub" x="20" y="330">$0</text>
+                        <text x="417" y="330" font-size="11.5" font-weight="600" fill="#e8431c" text-anchor="middle">cut here</text>
+                        <text class="lbl lbl--sub" x="500" y="330" text-anchor="end">cap</text>
+                    </svg>
+                    <div class="cap">Enforcement, not observability: the circuit is cut before the money is gone</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-engram" data-parent="products">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Flagship · Memory layer</span>
+                    <h2>Engram</h2>
+                    <p class="lede">An embeddable, local-first memory layer for AI agents: the SQLite of agent memory.
+                    One file on disk models episodic and semantic memory with bitemporal validity, importance decay
+                    and spreading-activation recall, and every answer can explain itself.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Single-file SQLite store: no server, no network call at write time</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Episodic and semantic memory with Ebbinghaus-style importance decay</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Spreading-activation retrieval over full-text and vector search</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Bitemporal validity: what was true, and when the agent believed it</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Provenance built in: why() traces the origin of every recall</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>MCP server exposes remember / recall / why / forget to any agent runtime</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Python 3.11+</span><span class="chip">SQLite</span><span class="chip">sqlite-vec</span>
+                        <span class="chip">fastembed</span><span class="chip">MCP</span>
+                    </div>
+                    <div class="pdetail__links">
+                        <span class="chip chip--public">v2.2.0 on PyPI</span>
+                        <a class="linkout" href="https://pypi.org/project/engdbram/" target="_blank" rel="noopener">pip install engdbram
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg></a>
+                    </div>
+                </div>
+                <div class="diagram-card">
+                    <svg class="dg" viewBox="0 0 520 360" role="img" aria-label="Engram memory model: remember, recall and why calls over one SQLite file holding episodic and semantic memory with bitemporal validity and importance decay.">
+                        <defs><marker id="arr3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#14110f"/></marker></defs>
+                        <rect class="box box--soft" x="20" y="30" width="120" height="56" rx="10"/>
+                        <text class="lbl" x="80" y="55" text-anchor="middle" font-size="13.5">remember()</text>
+                        <text class="lbl lbl--sub" x="80" y="72" text-anchor="middle">no LLM needed</text>
+                        <rect class="box box--soft" x="20" y="150" width="120" height="56" rx="10"/>
+                        <text class="lbl" x="80" y="175" text-anchor="middle" font-size="13.5">recall()</text>
+                        <text class="lbl lbl--sub" x="80" y="192" text-anchor="middle">spreading activation</text>
+                        <rect class="box box--soft" x="20" y="270" width="120" height="56" rx="10"/>
+                        <text class="lbl" x="80" y="295" text-anchor="middle" font-size="13.5">why()</text>
+                        <text class="lbl lbl--sub" x="80" y="312" text-anchor="middle">provenance</text>
+
+                        <path d="M140 58 H196" stroke="#14110f" stroke-width="1.6" fill="none" marker-end="url(#arr3)"/>
+                        <path d="M196 178 H140" stroke="#14110f" stroke-width="1.6" fill="none" marker-end="url(#arr3)"/>
+                        <path d="M196 298 H140" stroke="#14110f" stroke-width="1.6" fill="none" marker-end="url(#arr3)"/>
+
+                        <rect x="200" y="20" width="300" height="320" rx="16" fill="#fff" stroke="#14110f" stroke-width="1.6"/>
+                        <rect x="200" y="20" width="300" height="42" rx="16" fill="#f4a91b"/>
+                        <rect x="200" y="44" width="300" height="18" fill="#f4a91b"/>
+                        <text x="350" y="47" text-anchor="middle" font-size="14" font-weight="600" fill="#14110f">one SQLite file</text>
+
+                        <rect class="box box--soft" x="222" y="84" width="122" height="52" rx="9"/>
+                        <text class="lbl" x="283" y="106" text-anchor="middle" font-size="12.5">episodic</text>
+                        <text class="lbl lbl--sub" x="283" y="123" text-anchor="middle">what happened</text>
+                        <rect class="box box--soft" x="356" y="84" width="122" height="52" rx="9"/>
+                        <text class="lbl" x="417" y="106" text-anchor="middle" font-size="12.5">semantic</text>
+                        <text class="lbl lbl--sub" x="417" y="123" text-anchor="middle">what is known</text>
+
+                        <rect class="box box--soft" x="222" y="152" width="256" height="52" rx="9"/>
+                        <text class="lbl" x="350" y="174" text-anchor="middle" font-size="12.5">bitemporal validity</text>
+                        <text class="lbl lbl--sub" x="350" y="191" text-anchor="middle">valid time × belief time</text>
+
+                        <rect class="box box--soft" x="222" y="220" width="256" height="96" rx="9"/>
+                        <text class="lbl" x="350" y="243" text-anchor="middle" font-size="12.5">importance decay</text>
+                        <path d="M242 300 C282 258 330 254 380 262 C420 268 448 274 462 278" stroke="#e8431c" stroke-width="2" fill="none"/>
+                        <circle cx="298" cy="257" r="3.5" fill="#d98c00"/>
+                        <text class="lbl lbl--sub" x="306" y="252" font-size="10.5">reinforced</text>
+                    </svg>
+                    <div class="cap">Memory that fades, reinforces and explains itself, in one local file</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-sphereos" data-parent="products">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Flagship · Personal AI</span>
+                    <h2>SphereOS</h2>
+                    <p class="lede">Personal life intelligence, fully on-device. Twelve life domains, each with its own
+                    AI agent and its own Engram memory, joined by a Life Score, a morning brief and a correlation
+                    engine framed as pattern, not proof.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Twelve life-domain agents, from Health and Finance to Creativity and Goals</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>On-device Engram memory with fading and reinforcing recall</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Life Score, Today's Focus, weekly narrative review and Life Wheel</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>N-of-1 self-experiments and a Year in Sphere recap</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Universal capture: type it, dictate it, or photo a receipt</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Zero setup: no account, and deterministic features need no model at all</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Swift 6</span><span class="chip">SwiftUI</span><span class="chip">GRDB</span>
+                        <span class="chip">CloudKit</span><span class="chip">HealthKit</span><span class="chip">watchOS</span>
+                    </div>
+                    <div class="pdetail__links">
+                        <span class="chip chip--status">In development</span>
+                        <span class="private-note">App Store launch to be announced</span>
+                    </div>
+                </div>
+                <div class="diagram-card">
+                    <svg class="dg" viewBox="0 0 520 360" role="img" aria-label="SphereOS: twelve life domains arranged around one Life Score, each with its own agent and on-device Engram memory.">
+                        <circle cx="260" cy="175" r="56" fill="#f4a91b" stroke="#14110f" stroke-width="1.6"/>
+                        <text x="260" y="170" text-anchor="middle" font-size="14" font-weight="600" fill="#14110f">Life Score</text>
+                        <text x="260" y="188" text-anchor="middle" font-size="10.5" fill="#4b443d">one number, honest</text>
+                        <g font-size="11.5" font-weight="500" fill="#14110f" text-anchor="middle">
+                            <g transform="translate(260,45)"><rect x="-42" y="-14" width="84" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Health</text></g>
+                            <g transform="translate(388,72)"><rect x="-42" y="-14" width="84" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Learning</text></g>
+                            <g transform="translate(452,140)"><rect x="-40" y="-14" width="80" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Career</text></g>
+                            <g transform="translate(452,212)"><rect x="-42" y="-14" width="84" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Finance</text></g>
+                            <g transform="translate(388,280)"><rect x="-52" y="-14" width="104" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Relationships</text></g>
+                            <g transform="translate(260,308)"><rect x="-36" y="-14" width="72" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Rest</text></g>
+                            <g transform="translate(132,280)"><rect x="-42" y="-14" width="84" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Hobbies</text></g>
+                            <g transform="translate(68,212)"><rect x="-38" y="-14" width="76" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Travel</text></g>
+                            <g transform="translate(68,140)"><rect x="-50" y="-14" width="100" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Mindfulness</text></g>
+                            <g transform="translate(132,72)"><rect x="-46" y="-14" width="92" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Creativity</text></g>
+                            <g transform="translate(180,330)"><rect x="-36" y="-14" width="72" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Home</text></g>
+                            <g transform="translate(340,330)"><rect x="-36" y="-14" width="72" height="28" rx="14" fill="#fff" stroke="#14110f" stroke-width="1.2"/><text y="4">Goals</text></g>
+                        </g>
+                        <text x="260" y="245" text-anchor="middle" font-size="10.5" fill="#8a8175">every domain: its own agent · its own Engram memory · on-device</text>
+                    </svg>
+                    <div class="cap">Twelve agents around one score, and nothing leaves the phone</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-idryx" data-parent="stack" data-hl="idryx">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Identity plane</span>
+                    <h2>Idryx</h2>
+                    <p class="lede">The Identity Security Graph. Idryx reads identity logs from Okta, Entra, AWS, GCP,
+                    Azure and Keycloak, normalizes humans, service accounts, keys and AI agents into one graph,
+                    and runs deterministic detectors over it. Read-only by design: Idryx proposes, it never mutates.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>One graph for human and non-human identities (ITDR + NHI)</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Deterministic detectors: never an LLM in the detection path</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Behavioral baselines: impossible travel, MFA fatigue, new device</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Runaway-agent detector correlated with TokenFuse spend events</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Blast-radius view for any compromised identity</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Remediation as pull requests and alerts to SIEM, Slack or OTLP</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Go</span><span class="chip">Postgres</span><span class="chip">Okta</span>
+                        <span class="chip">Entra ID</span><span class="chip">AWS · GCP · Azure</span><span class="chip">Keycloak</span>
+                    </div>
+                    <div class="pdetail__links"><span class="chip chip--status">Private beta</span></div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-qryx" data-parent="stack" data-hl="qryx">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Cryptography plane</span>
+                    <h2>Qryx</h2>
+                    <p class="lede">The Cryptography Security Graph. Qryx inventories every use of cryptography across
+                    source code, binaries, containers, live TLS, certificates and cloud KMS, scores post-quantum risk,
+                    and emits a CycloneDX CBOM your auditors can actually read.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>One crypto inventory: code, binaries, containers, TLS, certificates, KMS</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Post-quantum risk scoring and crypto-agility mapping (Ed25519 to ML-DSA)</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>CycloneDX CBOM, plus NCSC and CNSA 2.0 readiness reports</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>CI gates on cryptographic drift and policy</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Safe automated remediation: qryx fix, up to an opened pull request</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Signed evidence trails for compliance</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Go</span><span class="chip">CycloneDX</span><span class="chip">NCSC PQC</span>
+                        <span class="chip">CNSA 2.0</span><span class="chip">AWS · GCP · Azure KMS</span>
+                    </div>
+                    <div class="pdetail__links"><span class="chip chip--status">Private beta</span></div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-wardryx" data-parent="stack" data-hl="wardryx">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Policy plane</span>
+                    <h2>Wardryx</h2>
+                    <p class="lede">The policy decision point of the stack. Before TokenFuse forwards an LLM or tool
+                    call, it asks Wardryx once: allow, deny, or hold. A hold is stateless human-in-the-loop, resolved
+                    out-of-band with a signed approval token. Deterministic, and explainable to an auditor.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>One call, three answers: allow, deny, or hold</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Human-in-the-loop above a spend threshold you set</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Spend levers as policy: deny tools, cap steps, allow-list domains</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Stateless signed approval tokens, optionally single-use</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Shadow mode first, enforce mode when you are ready</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Every decision reproducible: no LLM in the loop</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Go</span><span class="chip">Postgres</span><span class="chip">Signed approvals</span>
+                    </div>
+                    <div class="pdetail__links"><span class="chip chip--status">Private beta</span></div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-verdryx" data-parent="stack" data-hl="verdryx">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Quality plane</span>
+                    <h2>Verdryx</h2>
+                    <p class="lede">The quality denominator under your AI spend. Verdryx reads TokenFuse's
+                    outcome-tagged traces, grades agent outputs, and answers the question finance actually asks:
+                    not what a call cost, but what one correctly resolved case cost.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Cost-per-outcome, bucketed by resolved, escalated and abandoned</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Graders from exact-match to a priced LLM judge (its own cost is counted too)</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Quality-drift detection against a baseline: on-track or regressed</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Cost and quality join on one key: the outcome tag</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Catches a regression before wrong answers show up on the bill</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Python 3.11+</span><span class="chip">Parquet</span><span class="chip">SQLite</span><span class="chip">LLM judge</span>
+                    </div>
+                    <div class="pdetail__links"><span class="chip chip--status">Private beta</span></div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-mockryx" data-parent="stack" data-hl="mockryx">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Rehearsal plane</span>
+                    <h2>Mockryx</h2>
+                    <p class="lede">Fire drills for your guardrails. Before agents reach production, Mockryx replays
+                    hostile scenarios against your own TokenFuse gateway in mock-upstream mode: nothing real is spent
+                    and nothing external is touched. It then asserts that every guardrail actually fired.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Scenario families: runaway budget, forbidden tool call, secret leak</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Runs against your own gateway only: defensive rehearsal, never an attack tool</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Uses the gateway's native mock upstream, so drills exercise the real enforcement path</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Differentiated CI exit codes: 0 all held, 1 real gap found, 2 broken harness</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Findings flow onto the shared event bus for the rest of the stack</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Go</span><span class="chip">YAML scenarios</span><span class="chip">CI gate</span>
+                    </div>
+                    <div class="pdetail__links"><span class="chip chip--status">Private beta</span></div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+        <div class="pdetail" id="detail-contract" data-parent="stack" data-hl="contract">
+            <button class="back">&larr; All products</button>
+            <div class="pdetail__grid">
+                <div>
+                    <span class="eyebrow">Stack · Shared contract</span>
+                    <h2>agent-stack-go</h2>
+                    <p class="lede">The one public repo in the stack: a stdlib-only Go module defining the agent-event
+                    envelope and the Agent Passport types every service imports, so producer and consumer can never
+                    drift apart. Pinned by tag, never by a local replace.</p>
+                    <ul class="feat">
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>passport: the Agent Passport document, parsing and URI validation</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>event: the NDJSON envelope with Writer, Scan and ReadFile</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>chain: delegation-chain validation, acyclic and root-first</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Stdlib-only: zero network dependencies</li>
+                        <li><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Event schema versions independently of the passport schema, so new emitters are additive</li>
+                    </ul>
+                    <div class="pdetail__tags">
+                        <span class="chip">Go 1.26</span><span class="chip">stdlib-only</span><span class="chip">pkg.go.dev</span>
+                    </div>
+                    <div class="pdetail__links">
+                        <span class="chip chip--public">Public · v0.1.0</span>
+                        <a class="linkout" href="https://github.com/TAIPANBOX/agent-stack-go" target="_blank" rel="noopener">github.com/TAIPANBOX/agent-stack-go
+                            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 17L17 7M9 7h8v8"/></svg></a>
+                    </div>
+                </div>
+                <div class="diagram-slot"></div>
+            </div>
+        </div>
+
+    </div>
+</section>
+
+<!-- ============ CTA STRIP ============ -->
+<section class="section section--tight">
+    <div class="wrap">
+        <div class="pband reveal">
+            <div class="pband__inner">
+                <div>
+                    <span class="eyebrow">Work with us</span>
+                    <h2>Want these guardrails around your AI rollout?</h2>
+                    <p>The same architecture behind these products, budgets, policy, identity and audit for AI agents,
+                    is what we design and embed for clients. Tell us where it hurts and we'll come back with a
+                    concrete first step.</p>
+                    <a class="btn btn--primary" href="/#contact">Book a discovery call <span class="arr">&rarr;</span></a>
+                </div>
+                <div class="pband__cards">
+                    <div class="mini"><b>Assess</b><span>security posture + cost structure</span></div>
+                    <div class="mini"><b>Architect</b><span>guardrails, policy &amp; FinOps model</span></div>
+                    <div class="mini"><b>Embed</b><span>implemented alongside your team</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+</main>
+
+<!-- ============ FOOTER ============ -->
+<footer class="footer">
+    <div class="wrap">
+        <div class="footer__top">
+            <div>
+                <a class="brand" href="/"><img src="/img/29.png" alt="IT-RAT logo"><span class="brand__txt">IT<i>-RAT</i></span></a>
+                <p class="footer__tag">Boutique cloud consultancy for enterprise. We adopt AI across cloud, FinOps and security, and keep it secure, cost-governed and compliant.</p>
+            </div>
+            <div class="footer__social">
+                <a href="https://www.linkedin.com/in/it-rat-117084146/" target="_blank" rel="noopener" aria-label="LinkedIn">
+                    <svg viewBox="0 0 24 24"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.1c0-1.7-.03-3.9-2.38-3.9-2.38 0-2.75 1.86-2.75 3.78V24h-4V8z"/></svg>
+                </a>
+                <a href="https://twitter.com/ITRatSoftDev" target="_blank" rel="noopener" aria-label="Twitter / X">
+                    <svg viewBox="0 0 24 24"><path d="M18.9 2H22l-7.5 8.6L23 22h-6.8l-5.3-7-6.1 7H1.7l8-9.2L1 2h7l4.8 6.4L18.9 2zm-2.4 18h1.9L7.6 4H5.6l10.9 16z"/></svg>
+                </a>
+                <a href="https://www.facebook.com/ItRatSoftDev/" target="_blank" rel="noopener" aria-label="Facebook">
+                    <svg viewBox="0 0 24 24"><path d="M14 9h3V5h-3c-2.2 0-4 1.8-4 4v2H7v4h3v8h4v-8h3l1-4h-4V9c0-.6.4-1 1-1z"/></svg>
+                </a>
+                <a href="https://www.instagram.com/itratsoftdev/" target="_blank" rel="noopener" aria-label="Instagram">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1" fill="currentColor" stroke="none"/></svg>
+                </a>
+            </div>
+        </div>
+        <div class="footer__bottom">
+            <span>&copy; <span id="year">2026</span> IT-RAT. All rights reserved.<svg class="flag-ua" viewBox="0 0 24 16" role="img" aria-label="Ukraine"><title>Ukraine</title><rect width="24" height="8" fill="#0057B7"/><rect y="8" width="24" height="8" fill="#FFD700"/></svg></span>
+            <span>AI Governance · Cloud Security · FinOps</span>
+        </div>
+    </div>
+</footer>
+
+<script>
+(function () {
+    var nav = document.getElementById('nav');
+    var toggle = document.getElementById('navtoggle');
+    var links = document.getElementById('navlinks');
+
+    // sticky border on scroll
+    var onScroll = function () {
+        nav.classList.toggle('scrolled', window.scrollY > 12);
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+
+    // mobile menu
+    toggle.addEventListener('click', function () {
+        var open = nav.classList.toggle('open');
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+    links.addEventListener('click', function (e) {
+        if (e.target.tagName === 'A') nav.classList.remove('open');
+    });
+
+    // scroll reveal (rect-based, same approach as the homepage)
+    var revealEls = [].slice.call(document.querySelectorAll('.reveal'));
+    var revealCheck = function () {
+        var vh = window.innerHeight || document.documentElement.clientHeight;
+        for (var i = revealEls.length - 1; i >= 0; i--) {
+            if (revealEls[i].getBoundingClientRect().top < vh * 0.9) {
+                revealEls[i].classList.add('in');
+                revealEls.splice(i, 1);
+            }
+        }
+    };
+    var rafQueued = false;
+    var onReveal = function () {
+        if (rafQueued) return;
+        rafQueued = true;
+        requestAnimationFrame(function () { rafQueued = false; revealCheck(); });
+    };
+    window.addEventListener('scroll', onReveal, { passive: true });
+    window.addEventListener('resize', onReveal);
+    window.addEventListener('load', revealCheck);
+    revealCheck();
+
+    // current year
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    // scroll progress bar
+    var bar = document.getElementById('scrollbar');
+    var onProgress = function () {
+        var h = document.documentElement.scrollHeight - window.innerHeight;
+        bar.style.width = (h > 0 ? (window.scrollY / h) * 100 : 0) + '%';
+    };
+    window.addEventListener('scroll', onProgress, { passive: true });
+    onProgress();
+
+    // ---------- products: tabs, detail views, hash deep links ----------
+    var tabs = [].slice.call(document.querySelectorAll('.ptab'));
+    var panes = { products: document.getElementById('tab-products'), stack: document.getElementById('tab-stack') };
+    var details = [].slice.call(document.querySelectorAll('.pdetail'));
+    var tabbar = document.getElementById('tabbar');
+
+    function showTab(name) {
+        tabs.forEach(function (t) { t.setAttribute('aria-selected', String(t.dataset.tab === name)); });
+        Object.keys(panes).forEach(function (k) { panes[k].hidden = (k !== name); });
+    }
+
+    function closeDetails() {
+        details.forEach(function (d) { d.classList.remove('open'); });
+        tabbar.style.display = '';
+        Object.keys(panes).forEach(function (k) { panes[k].style.display = ''; });
+    }
+
+    function openDetail(id, instant) {
+        var d = document.getElementById('detail-' + id);
+        if (!d) return;
+        closeDetails();
+        tabbar.style.display = 'none';
+        Object.keys(panes).forEach(function (k) { panes[k].style.display = 'none'; });
+        d.classList.add('open');
+        injectStackDiagram(d);
+        d.scrollIntoView({ behavior: instant ? 'auto' : 'smooth', block: 'start' });
+    }
+
+    // clone the big stack SVG into service detail slots, highlighting one node
+    var stackSvg = document.querySelector('#tab-stack .diagram-card svg');
+    function injectStackDiagram(detail) {
+        var slot = detail.querySelector('.diagram-slot');
+        var hl = detail.dataset.hl;
+        if (!slot || !hl || slot.dataset.done) return;
+        var card = document.createElement('div');
+        card.className = 'diagram-card';
+        var clone = stackSvg.cloneNode(true);
+        clone.classList.add('dg-hl');
+        // unique marker ids per clone to avoid collisions
+        var suffix = '-' + hl;
+        [].forEach.call(clone.querySelectorAll('marker'), function (m) { m.id += suffix; });
+        [].forEach.call(clone.querySelectorAll('[marker-end]'), function (p) {
+            p.setAttribute('marker-end', p.getAttribute('marker-end').replace(')', suffix + ')'));
+        });
+        var node = clone.querySelector('[data-node="' + hl + '"]');
+        if (node) node.classList.add('on');
+        // tokenfuse stays visible as the anchor everything relates to
+        var tf = clone.querySelector('[data-node="tokenfuse"]');
+        if (tf && hl !== 'tokenfuse') tf.classList.add('on');
+        card.appendChild(clone);
+        var cap = document.createElement('div');
+        cap.className = 'cap';
+        cap.textContent = 'Where it sits in the stack';
+        card.appendChild(cap);
+        slot.appendChild(card);
+        slot.dataset.done = '1';
+    }
+
+    tabs.forEach(function (t) {
+        t.addEventListener('click', function () {
+            closeDetails();
+            showTab(t.dataset.tab);
+            history.replaceState(null, '', '#' + (t.dataset.tab === 'stack' ? 'stack' : 'products'));
+        });
+    });
+    [].forEach.call(document.querySelectorAll('.pcard[data-detail]'), function (c) {
+        c.addEventListener('click', function () {
+            var id = c.dataset.detail;
+            history.replaceState(null, '', '#' + id);
+            openDetail(id);
+        });
+    });
+    [].forEach.call(document.querySelectorAll('.back'), function (b) {
+        b.addEventListener('click', function () {
+            var parent = b.closest('.pdetail').dataset.parent;
+            closeDetails();
+            showTab(parent);
+            history.replaceState(null, '', '#' + (parent === 'stack' ? 'stack' : 'products'));
+            tabbar.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        });
+    });
+
+    // hash deep links: #stack, #tokenfuse, #wardryx, …
+    var h = location.hash.replace('#', '');
+    if (h === 'stack') showTab('stack');
+    else if (h && h !== 'products' && document.getElementById('detail-' + h)) {
+        showTab(document.getElementById('detail-' + h).dataset.parent);
+        openDetail(h, true);
+    }
+})();
+</script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://it-rat.github.io/</loc>
-    <lastmod>2026-07-01</lastmod>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://it-rat.github.io/products/</loc>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
   </url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -505,3 +505,208 @@ h1, h2, h3, h4 {
   .reveal { opacity: 1; transform: none; }
   html { scroll-behavior: auto; }
 }
+
+/* ---------- Products page ---------- */
+.nav__links > a[aria-current="page"] { color: var(--ink); font-weight: 600; }
+.nav__links > a[aria-current="page"]::after { transform: scaleX(1); }
+
+.phero { padding: 72px 0 10px; }
+.phero h1 { font-size: clamp(36px, 5vw, 62px); margin: 0 0 22px; max-width: 16ch; }
+.phero h1 .hl { position: relative; white-space: nowrap; }
+.phero h1 .hl::after {
+  content: "";
+  position: absolute;
+  left: -2px; right: -2px; bottom: 5px;
+  height: 28%;
+  background: var(--amber);
+  z-index: -1;
+  opacity: .85;
+}
+
+.ptabs { display: flex; gap: 12px; margin: 10px 0 34px; flex-wrap: wrap; }
+.ptab {
+  font-family: var(--font-head);
+  font-weight: 600;
+  font-size: 15px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 2px solid var(--ink);
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background .2s, color .2s, transform .2s var(--ease);
+}
+.ptab:hover { transform: translateY(-2px); }
+.ptab[aria-selected="true"] { background: var(--ink); color: var(--paper); }
+.ptab .n {
+  display: inline-grid; place-items: center;
+  min-width: 22px; height: 22px; border-radius: 999px;
+  background: var(--amber); color: var(--ink);
+  font-size: 12px; margin-left: 8px; padding: 0 4px;
+}
+
+.pgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
+.pcard {
+  border: 1px solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--white);
+  padding: 28px;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  transition: transform .3s var(--ease), box-shadow .3s var(--ease);
+}
+.pcard:hover, .pcard:focus-visible { transform: translateY(-5px); box-shadow: var(--shadow); outline: none; }
+.pcard:focus-visible { border-color: var(--red); }
+.pcard::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 5px; background: var(--accent, var(--amber)); }
+.pcard--red { --accent: var(--red); }
+.pcard--amber { --accent: var(--amber); }
+.pcard--ink { --accent: var(--ink); }
+.pcard__icon {
+  width: 48px; height: 48px; border-radius: 12px;
+  display: grid; place-items: center;
+  background: var(--paper-2);
+  border: 1px solid var(--ink);
+  margin-bottom: 18px;
+}
+.pcard__icon svg { width: 24px; height: 24px; stroke: var(--ink); fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+.pcard h3 { font-size: 22px; margin-bottom: 4px; }
+.pcard__plane {
+  font-family: var(--font-head);
+  font-size: 11.5px; font-weight: 600;
+  letter-spacing: .12em; text-transform: uppercase;
+  color: var(--red);
+  margin-bottom: 10px;
+}
+.pcard > p { color: var(--ink-soft); font-size: 14.5px; margin: 0 0 16px; flex: 1; }
+.pcard__meta { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 16px; }
+.pcard__more { font-family: var(--font-head); font-weight: 600; font-size: 14.5px; display: inline-flex; align-items: center; gap: 8px; }
+.pcard__more .arr { transition: transform .25s var(--ease); }
+.pcard:hover .pcard__more .arr { transform: translateX(4px); }
+
+.chip {
+  font-family: var(--font-head);
+  font-size: 12px; font-weight: 500;
+  padding: 4px 11px;
+  background: var(--paper-2);
+  border-radius: 999px;
+  border: 1px solid rgba(20,17,15,.18);
+}
+.chip--status { background: var(--white); border-color: var(--amber-deep); color: var(--amber-deep); font-weight: 600; }
+.chip--public { background: var(--white); border-color: #1c7a3d; color: #1c7a3d; font-weight: 600; }
+
+.stack-note {
+  display: flex; gap: 12px; align-items: flex-start;
+  border: 1px solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--paper-2);
+  padding: 18px 22px;
+  margin: 0 0 28px;
+  font-size: 14.5px;
+  color: var(--ink-soft);
+}
+.stack-note svg { width: 22px; height: 22px; flex: 0 0 auto; stroke: var(--ink); fill: none; stroke-width: 1.8; margin-top: 2px; }
+.stack-note b { color: var(--ink); }
+
+.diagram-card {
+  border: 1px solid var(--ink);
+  border-radius: var(--radius);
+  background: var(--white);
+  padding: 22px;
+  box-shadow: var(--shadow);
+  overflow-x: auto;
+}
+.diagram-card .cap {
+  font-family: var(--font-head);
+  font-size: 12px; font-weight: 600;
+  letter-spacing: .1em; text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 12px; text-align: center;
+}
+.dg { width: 100%; height: auto; display: block; font-family: var(--font-head); }
+.dg .box { fill: var(--white); stroke: var(--ink); stroke-width: 1.5; }
+.dg .box--soft { fill: var(--paper-2); }
+.dg .box--amber { fill: var(--amber); }
+.dg .box--ink { fill: var(--ink); }
+.dg .lbl { fill: var(--ink); font-size: 15px; font-weight: 600; }
+.dg .lbl--sub { font-size: 11.5px; font-weight: 500; fill: var(--ink-soft); }
+.dg .lbl--inv { fill: var(--paper); }
+.dg .lbl--tag { font-size: 10.5px; font-weight: 600; letter-spacing: .08em; fill: var(--amber-deep); }
+.dg .flow { stroke: var(--ink); stroke-width: 1.6; fill: none; marker-end: url(#arr); }
+.dg .flow--dash { stroke-dasharray: 5 5; }
+.dg .flow--red { stroke: var(--red); marker-end: url(#arr-red); }
+.dg .buslbl { font-size: 12px; font-weight: 600; fill: var(--ink); }
+/* per-service highlight inside the cloned stack diagram */
+.dg-hl [data-node] { opacity: .38; }
+.dg-hl [data-node].on { opacity: 1; }
+.dg-hl [data-node].on .hlring { stroke: var(--red); stroke-width: 2.5; }
+
+.pdetail { display: none; padding: 8px 0 10px; }
+.pdetail.open { display: block; }
+.back {
+  display: inline-flex; align-items: center; gap: 9px;
+  font-family: var(--font-head); font-weight: 600; font-size: 14.5px;
+  margin-bottom: 30px; cursor: pointer;
+  background: none; border: 0; color: var(--ink); padding: 0;
+}
+.back:hover { color: var(--red); }
+.pdetail__grid { display: grid; grid-template-columns: 1.02fr .98fr; gap: 44px; align-items: start; }
+.pdetail h2 { font-size: clamp(30px, 4vw, 44px); margin-bottom: 16px; }
+.pdetail .lede { font-size: 17px; margin-bottom: 26px; }
+.feat { list-style: none; margin: 0 0 26px; padding: 0; display: grid; gap: 11px; }
+.feat li { display: flex; gap: 11px; font-size: 15px; color: var(--ink-soft); align-items: flex-start; }
+.feat li svg { width: 17px; height: 17px; flex: 0 0 auto; margin-top: 4px; stroke: var(--red); fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+.pdetail__tags { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px; }
+.pdetail__links { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.linkout { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-head); font-weight: 600; font-size: 14.5px; }
+.linkout:hover { color: var(--red); }
+.linkout svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; }
+.private-note { font-size: 13px; color: var(--muted); font-family: var(--font-head); font-weight: 500; }
+.private-note a { text-decoration: underline; }
+.private-note a:hover { color: var(--red); }
+
+/* products band (homepage teaser + products-page CTA) */
+.pband { background: linear-gradient(135deg, #14110f 0%, #221c16 100%); color: var(--paper); border-radius: 28px; overflow: hidden; position: relative; }
+.pband::before {
+  content: ""; position: absolute; inset: -50%;
+  background: radial-gradient(circle at 30% 30%, rgba(244,169,27,.20), transparent 40%),
+              radial-gradient(circle at 70% 70%, rgba(232,67,28,.18), transparent 42%);
+  animation: glow-rotate 20s linear infinite;
+}
+.pband__inner { position: relative; z-index: 1; display: grid; grid-template-columns: 1fr .95fr; gap: 46px; align-items: center; padding: 56px; }
+.pband .eyebrow { color: var(--amber); }
+.pband .eyebrow::before { background: var(--red); }
+.pband h2 { color: #fff; font-size: clamp(26px, 3.2vw, 38px); margin-bottom: 16px; }
+.pband p { color: #cfc8bc; max-width: 52ch; font-size: 16px; margin: 0 0 26px; }
+.pband .btn--primary { background: var(--amber); color: var(--ink); border-color: var(--amber); }
+.pband .btn--primary:hover { background: var(--red); border-color: var(--red); color: #fff; }
+.pband__cards { display: grid; gap: 14px; }
+.pband__cards .mini {
+  border: 1px solid rgba(247,243,236,.22);
+  border-radius: 14px;
+  padding: 16px 20px;
+  display: flex; align-items: baseline; justify-content: space-between; gap: 14px;
+}
+.pband__cards .mini b { font-family: var(--font-head); font-size: 17px; color: #fff; font-weight: 600; }
+.pband__cards .mini span { font-size: 13px; color: #cfc8bc; text-align: right; }
+
+/* staggered reveal for product cards */
+.pgrid .reveal:nth-child(2) { transition-delay: .12s; }
+.pgrid .reveal:nth-child(3) { transition-delay: .24s; }
+.pgrid .reveal:nth-child(5) { transition-delay: .12s; }
+.pgrid .reveal:nth-child(6) { transition-delay: .24s; }
+
+@media (max-width: 940px) {
+  .pgrid { grid-template-columns: 1fr 1fr; }
+  .pdetail__grid, .pband__inner { grid-template-columns: 1fr; }
+  .pband__inner { padding: 40px 28px; gap: 32px; }
+}
+@media (max-width: 560px) {
+  .pgrid { grid-template-columns: 1fr; }
+  .phero { padding-top: 52px; }
+}


### PR DESCRIPTION
## What

A new **/products/** page presenting the software behind the consultancy, plus a Products link in the nav and a teaser band on the homepage after the AI section.

- Two tabs: **Flagship products** (TokenFuse, Engram, SphereOS) and **Agent governance stack** (Idryx, Qryx, Wardryx, Verdryx, Mockryx, agent-stack-go)
- Each card opens an in-page detail view: feature list, tech chips, status, and an inline SVG diagram in the site palette (no PNGs)
- The stack tab carries one shared architecture diagram; each service detail re-uses it with that service's node highlighted
- Hash deep links work with zero backend: /products/#tokenfuse, /products/#stack, etc.
- Same design system throughout: existing palette, buttons, cards, reveal animations; ~205 lines of additive CSS, no changes to existing rules

## Deliberate choices

- **Only public artifacts are linked outward**: agent-stack-go (GitHub) and Engram (engdbram on PyPI). Everything else is labelled Private beta / In development with no repo links.
- The stack tab opens with a 'Defensive by design' note, and Mockryx is described strictly as fire drills against your own gateway.

## Verification

Served locally over HTTP and exercised: tab switching, all nine detail views, diagram cloning + node highlight, hash deep links, homepage teaser link, mobile nav. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)