### PR TITLE
chore: set custom domain it-rat.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+it-rat.com


### PR DESCRIPTION
Adds a `CNAME` file so GitHub Pages serves the site on **it-rat.com**.

DNS is already configured at Cloudflare and verified resolving:
- four A records on the apex → GitHub Pages IPs (185.199.108–111.153)
- `www` CNAME → it-rat.github.io
- all records DNS-only (grey cloud), so GitHub issues the HTTPS cert

After merge: enable **Enforce HTTPS** in Settings → Pages once the cert is issued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)