### PR TITLE
seo: point canonical/OG/sitemap at it-rat.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
     <meta name="description" content="IT-RAT is a boutique cloud consultancy. We help enterprises adopt AI across cloud, FinOps and security, and keep that full-scale AI rollout secure, cost-governed and compliant. Zero Trust, IAM, FinOps for AI and platform engineering across AWS and GCP.">
     <meta name="keywords" content="Secure AI, AI Governance, FinOps for AI, LLM, GenAI, AI workloads, Cloud Security, IAM, Zero Trust, FinOps, Cloud Cost Optimization, DevSecOps, AWS, GCP, Kubernetes, Terraform">
     <link rel="shortcut icon" type="image/png" href="favicon.png">
-    <link rel="canonical" href="https://it-rat.github.io/">
+    <link rel="canonical" href="https://it-rat.com/">
     <meta property="og:title" content="IT-RAT: Secure, Governed AI for Enterprise">
     <meta property="og:description" content="Adopt AI everywhere, kept secure, cost-governed and compliant. Senior cloud security, FinOps and AI architecture for complex, high-stakes projects.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://it-rat.github.io/">
-    <meta property="og:image" content="https://it-rat.github.io/img/og-card.png">
+    <meta property="og:url" content="https://it-rat.com/">
+    <meta property="og:image" content="https://it-rat.com/img/og-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="IT-RAT: Secure, Governed AI for Enterprise">
     <meta name="twitter:description" content="Adopt AI everywhere, kept secure, cost-governed and compliant. Senior cloud security, FinOps and AI architecture for complex, high-stakes projects.">
-    <meta name="twitter:image" content="https://it-rat.github.io/img/og-card.png">
+    <meta name="twitter:image" content="https://it-rat.com/img/og-card.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/products/index.html
+++ b/products/index.html
@@ -8,18 +8,18 @@
     <meta name="description" content="The software behind the consultancy: TokenFuse, a runtime FinOps kill-switch for AI agents; Engram, a local-first memory layer; SphereOS, on-device personal AI; and a six-service agent governance stack covering identity, cryptography, policy, quality and safety rehearsal.">
     <meta name="keywords" content="TokenFuse, Engram, SphereOS, AI agent governance, FinOps for AI, LLM budget enforcement, agent security, AI spend kill-switch, agent memory, ITDR, CBOM, post-quantum">
     <link rel="shortcut icon" type="image/png" href="/favicon.png">
-    <link rel="canonical" href="https://it-rat.github.io/products/">
+    <link rel="canonical" href="https://it-rat.com/products/">
     <meta property="og:title" content="IT-RAT Products: the tooling we recommend, built in-house">
     <meta property="og:description" content="A runtime FinOps gateway for AI agents, a local-first memory layer, and a six-service governance stack. Built and run by the same architects you work with.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://it-rat.github.io/products/">
-    <meta property="og:image" content="https://it-rat.github.io/img/og-card.png">
+    <meta property="og:url" content="https://it-rat.com/products/">
+    <meta property="og:image" content="https://it-rat.com/img/og-card.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="IT-RAT Products: the tooling we recommend, built in-house">
     <meta name="twitter:description" content="A runtime FinOps gateway for AI agents, a local-first memory layer, and a six-service governance stack. Built and run by the same architects you work with.">
-    <meta name="twitter:image" content="https://it-rat.github.io/img/og-card.png">
+    <meta name="twitter:image" content="https://it-rat.com/img/og-card.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://it-rat.github.io/sitemap.xml
+Sitemap: https://it-rat.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://it-rat.github.io/</loc>
+    <loc>https://it-rat.com/</loc>
     <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
   </url>
   <url>
-    <loc>https://it-rat.github.io/products/</loc>
+    <loc>https://it-rat.com/products/</loc>
     <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
   </url>


### PR DESCRIPTION
Now that the site is live on **it-rat.com**, update all self-referential URLs from `it-rat.github.io` so search engines index the canonical domain and social link previews resolve correctly.

- `index.html` + `products/index.html`: canonical, og:url, og:image, twitter:image
- `sitemap.xml`: both `<loc>` URLs
- `robots.txt`: Sitemap line

No visual change; meta only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)